### PR TITLE
Add basic Android activity to generate APK

### DIFF
--- a/src/android/build.gradle.kts
+++ b/src/android/build.gradle.kts
@@ -14,4 +14,25 @@ android {
         versionCode = 1
         versionName = "1.0"
     }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.10.1")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.9.0")
 }

--- a/src/android/src/main/AndroidManifest.xml
+++ b/src/android/src/main/AndroidManifest.xml
@@ -3,5 +3,11 @@
     package="com.aetherius">
     <application
         android:label="AETHERIUS">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/src/android/src/main/java/com/aetherius/MainActivity.kt
+++ b/src/android/src/main/java/com/aetherius/MainActivity.kt
@@ -1,0 +1,11 @@
+package com.aetherius
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+}

--- a/src/android/src/main/res/layout/activity_main.xml
+++ b/src/android/src/main/res/layout/activity_main.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hello, AETHERIUS!" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- scaffold Android app module with MainActivity and layout
- configure Gradle with build types, Java/Kotlin options, and dependencies
- register MainActivity in AndroidManifest

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4703eba848324b31ae9cd7fb755cb